### PR TITLE
Melhora configuração do Porcupine

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ mqtt_broker: "localhost"
 vosk_model_path: "models/vosk-model-small"
 whisper_model: "small"
 rasa_url: "http://localhost:5005/model/parse"
+pv_access_key: "SUA-CHAVE-PORCUPINE"
+pv_library_path: ""
+pv_model_path: ""
+pv_keyword_path: ""
+pv_sensitivity: 0.5
 ```
+
+Para usar a detecção de hot-word Porcupine, obtenha uma chave gratuita em
+[console.picovoice.ai](https://console.picovoice.ai/) e defina `pv_access_key`
+no `config.yaml` ou a variável de ambiente `PV_ACCESS_KEY`.
 
 ## Estrutura
 

--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,8 @@ mqtt_broker: "localhost"
 vosk_model_path: "models/vosk-model-small"
 whisper_model: "small"
 rasa_url: "http://localhost:5005/model/parse"
+pv_access_key: ""
+pv_library_path: ""
+pv_model_path: ""
+pv_keyword_path: ""
+pv_sensitivity: 0.5

--- a/lia/hotword.py
+++ b/lia/hotword.py
@@ -26,11 +26,18 @@ def play_beep():
 
 
 # Carrel parametrise do Porcupine via config.yaml ou variates de ambient
+# Carrega parâmetros do Porcupine via config.yaml ou variáveis de ambiente
 ACCESS_KEY = os.getenv("PV_ACCESS_KEY", config.PV_ACCESS_KEY)
 LIBRARY_PATH = os.getenv("PV_LIBRARY_PATH", config.PV_LIBRARY_PATH)
 MODEL_PATH = os.getenv("PV_MODEL_PATH", config.PV_MODEL_PATH)
 KEYWORD_PATH = os.getenv("PV_KEYWORD_PATH", config.PV_KEYWORD_PATH)
 SENSITIVITIES = [float(os.getenv("PV_SENSITIVITY", config.PV_SENSITIVITY))]
+
+if not ACCESS_KEY:
+    raise RuntimeError(
+        "PV_ACCESS_KEY n\u00e3o definido. Obtenha uma chave em https://console.picovoice.ai/ "
+        "e configure a vari\u00e1vel de ambiente ou 'pv_access_key' em config.yaml."
+    )
 # Instancia o detector de hot-word. Caso KEYWORD_PATH não esteja
 # definido, utiliza o modelo padrão "porcupine" embutido na biblioteca.
 if KEYWORD_PATH:


### PR DESCRIPTION
## Resumo
- adiciona parâmetros do Porcupine no `config.yaml`
- documenta chave `pv_access_key` no README
- valida presença de `PV_ACCESS_KEY` ao iniciar o hotword

## Testes
- `black . --line-length 120`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685469ad80b4832caca5d4fc8deb485c