### PR TITLE
Adiciona script de setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Em seguida, instale os pacotes do projeto com:
 pip install -r requirements.txt
 ```
 
+Se preferir, execute `./setup.sh` para instalar automaticamente as dependências
+nativas e os pacotes Python.
+
 ## Configuração
 
 Todas as opções de execução são lidas de `config.yaml`. Um exemplo é mostrado abaixo:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Instala dependências de áudio necessárias para pyaudio e simpleaudio
+sudo apt-get update
+sudo apt-get install -y portaudio19-dev libasound2-dev
+
+# Instala pacotes Python
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- adiciona script `setup.sh` para instalar dependências do sistema
- documenta uso do script no README

## Testing
- `black . --line-length 120`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546d3905ec832cbac7b6acc2eff142