### PR TITLE
Melhoria no setup do Porcupine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ pv_sensitivity: 0.5
 Para usar a detecção de hot-word Porcupine, obtenha uma chave gratuita em
 [console.picovoice.ai](https://console.picovoice.ai/) e defina `pv_access_key`
 no `config.yaml` ou a variável de ambiente `PV_ACCESS_KEY`.
+Se desejar um modelo de palavra-chave personalizado, informe o caminho do
+arquivo `.ppn` em `pv_keyword_path` (ou use a variável `PV_KEYWORD_PATH`).
+Caso nenhum caminho seja fornecido, o modelo padrão "porcupine" será usado.
 
 ## Estrutura
 

--- a/lia/hotword.py
+++ b/lia/hotword.py
@@ -43,8 +43,8 @@ if not ACCESS_KEY:
 if KEYWORD_PATH:
     porcupine = Porcupine(
         access_key=ACCESS_KEY,
-        library_path=LIBRARY_PATH,
-        model_path=MODEL_PATH,
+        library_path=LIBRARY_PATH or None,
+        model_path=MODEL_PATH or None,
         keyword_paths=[KEYWORD_PATH],
         sensitivities=SENSITIVITIES,
     )


### PR DESCRIPTION
## Summary
- handle optional library/model paths when creating Porcupine
- document how to use `pv_keyword_path` in README

## Testing
- `pip install -r requirements.txt`
- `pip install black ruff pytest`
- `black . --line-length 120`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68546e514d24832ca2d2c1520b12f68e