### PR TITLE
Atualiza orientações do Porcupine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ no `config.yaml` ou a variável de ambiente `PV_ACCESS_KEY`.
 Se desejar um modelo de palavra-chave personalizado, informe o caminho do
 arquivo `.ppn` em `pv_keyword_path` (ou use a variável `PV_KEYWORD_PATH`).
 Caso nenhum caminho seja fornecido, o modelo padrão "porcupine" será usado.
+Se as bibliotecas do Porcupine estiverem fora do caminho padrão, defina também:
+```bash
+export PV_LIBRARY_PATH=/caminho/para/libpv_porcupine.so
+export PV_MODEL_PATH=/caminho/para/porcupine_params.pv
+export PV_SENSITIVITY=0.5
+```
+Esses valores podem ser configurados em `config.yaml`.
+
 
 ## Estrutura
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+# ruff: noqa: E402
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from lia.config import Config
+
+
+def test_env_override(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "c.yaml"
+    cfg_file.write_text("pv_access_key: 'filekey'\n")
+    monkeypatch.setenv("PV_ACCESS_KEY", "envkey")
+    cfg = Config(str(cfg_file))
+    assert cfg.PV_ACCESS_KEY == "envkey"


### PR DESCRIPTION
## Resumo
- complementa instruções de configuração do Porcupine no README
- adiciona teste para verificar precedência de variáveis de ambiente no `Config`

## Testes
- `black . --line-length 120`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546fc80758832caf253c3f9803e65f