### PR TITLE
Fix audio init for hotword

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Todas as instruções a seguir se aplicam a todo o repositório.
 
 - Utilize **Python 3.11**.
-- Antes de commitar rode os seguintes passos:
+- Antes de commitar rode os seguintes passos (após executar `./setup.sh` para instalar bibliotecas nativas):
 
 ```bash
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Este repositório reúne diversos módulos que juntos implementam a **Lia**, uma
   ```bash
   sudo apt-get install portaudio19-dev libasound2-dev
   ```
+- Principais bibliotecas Python:
+  pvporcupine, webrtcvad, pyaudio, vosk,
+  whispercpp, pyttsx3, simpleaudio, openai,
+  googletrans, sqlalchemy, pyyaml, requests,
+  kafka-python, paho-mqtt, PySide6,
+  opentelemetry-api, opentelemetry-sdk,
+  numpy
 
 ## Instalação
 
@@ -51,7 +58,20 @@ pv_library_path: ""
 pv_model_path: ""
 pv_keyword_path: ""
 pv_sensitivity: 0.5
+audio_input_device: null
 ```
+
+Use `audio_input_device` para especificar o índice do microfone quando existir
+mais de um dispositivo conectado. Para descobrir os índices disponíveis:
+
+```bash
+python - <<'EOF'
+import pyaudio, json
+pa = pyaudio.PyAudio()
+print(json.dumps({i: pa.get_device_info_by_index(i)["name"] for i in range(pa.get_device_count())}, indent=2))
+EOF
+```
+Também é possível definir o dispositivo via variável de ambiente `AUDIO_INPUT_DEVICE`.
 
 Para usar a detecção de hot-word Porcupine, obtenha uma chave gratuita em
 [console.picovoice.ai](https://console.picovoice.ai/) e defina `pv_access_key`

--- a/config.yaml
+++ b/config.yaml
@@ -18,3 +18,4 @@ pv_library_path: ""
 pv_model_path: ""
 pv_keyword_path: ""
 pv_sensitivity: 0.5
+audio_input_device: null

--- a/lia/config.py
+++ b/lia/config.py
@@ -39,6 +39,8 @@ class Config:
         self.PV_MODEL_PATH = os.getenv("PV_MODEL_PATH", data.get("pv_model_path", ""))
         self.PV_KEYWORD_PATH = os.getenv("PV_KEYWORD_PATH", data.get("pv_keyword_path", ""))
         self.PV_SENSITIVITY = float(os.getenv("PV_SENSITIVITY", data.get("pv_sensitivity", 0.5)))
+        device_env = os.getenv("AUDIO_INPUT_DEVICE")
+        self.AUDIO_INPUT_DEVICE = int(device_env) if device_env is not None else data.get("audio_input_device")
 
 
 # instantiate


### PR DESCRIPTION
## Summary
- allow configuring audio device
- open PyAudio stream only when starting hotword listener
- document dependencies and config options

## Testing
- `pip install -r requirements.txt`
- `pip install black ruff pytest`
- `black . --line-length 120`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685472db0e20832cae241b84c56f91a5