### PR TITLE
Corrige função vad_collector

### DIFF
--- a/lia/vad.py
+++ b/lia/vad.py
@@ -1,5 +1,6 @@
 # -- vad.py
 import webrtcvad
+from collections import deque
 from lia.logger import logger
 
 
@@ -15,50 +16,32 @@ def init_vad(mode: int = 1) -> webrtcvad.Vad:
 def vad_collector(
     vad: webrtcvad.Vad, frames: list[bytes], sample_rate: int = 16000, frame_ms: int = 30, padding_ms: int = 300
 ):
-    """
-    Gera segmentos de áudio voz a partir de uma lista de frames brutos.
+    """Gera segmentos de fala a partir de frames PCM."""
 
-    Parâmetros:
-      vad        : instância do VAD
-      frames     : lista de bytes (PCM 16-bit)
-      sample_rate: taxa de amostragem em Hz
-      frame_ms   : duração de cada frame em ms
-      padding_ms : duração de preenchimento para detecção
-
-    Retorna:
-      Iterador de segmentos de áudio de voz (bytes concatenados).
-    """
     num_padding = int(padding_ms / frame_ms)
-    ring_buffer: list[bytes] = []
+    ring_buffer: deque[tuple[bytes, bool]] = deque(maxlen=num_padding)
     voiced_frames: list[bytes] = []
     triggered = False
 
     for frame in frames:
+        is_speech = vad.is_speech(frame, sample_rate)
         if not triggered:
-            # Avalia se o frame atual contém fala
-            if vad.is_speech(frame, sample_rate):
-                ring_buffer.append(frame)
-            else:
-                ring_buffer.append(frame)
-            if sum(vad.is_speech(f, sample_rate) for f in ring_buffer) > 0.9 * num_padding:
+            ring_buffer.append((frame, is_speech))
+            num_voiced = len([1 for _, speech in ring_buffer if speech])
+            if num_voiced > 0.9 * ring_buffer.maxlen:
                 triggered = True
-                voiced_frames.extend(ring_buffer)
-                ring_buffer.clear()
-            ring_buffer.append(frame)
-            if sum(vad.is_speech(f, sample_rate) for f in ring_buffer) > 0.9 * num_padding:
-                triggered = True
-                voiced_frames.extend(ring_buffer)
+                voiced_frames.extend(f for f, _ in ring_buffer)
                 ring_buffer.clear()
         else:
             voiced_frames.append(frame)
-            ring_buffer.append(frame)
-            if sum(not vad.is_speech(f, sample_rate) for f in ring_buffer) > num_padding:
+            ring_buffer.append((frame, is_speech))
+            num_unvoiced = len([1 for _, speech in ring_buffer if not speech])
+            if num_unvoiced > ring_buffer.maxlen:
                 logger.debug("Yielding VAD segment")
                 yield b"".join(voiced_frames)
                 ring_buffer.clear()
                 voiced_frames.clear()
                 triggered = False
 
-    # Se ainda restarem frames de voz ao final, retorna
     if voiced_frames:
         yield b"".join(voiced_frames)


### PR DESCRIPTION
## Summary
- refatora `vad_collector` para eliminar lógica duplicada e usar `deque`

## Testing
- `black . --line-length 120`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68547b614254832ca67144bd247ba047